### PR TITLE
Hotfix/#14 nickname request

### DIFF
--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/domain/UserRepository.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/domain/UserRepository.kt
@@ -6,5 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface UserRepository : JpaRepository<UserEntity, Long> {
     fun findByEmail(email: String): UserEntity?
     fun existsByEmail(email: String): Boolean
+    fun existsByNickname(nickname: String): Boolean
     fun findByNickname(nickname: String): UserEntity?
 }

--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/domain/UserRepository.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/domain/UserRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface UserRepository : JpaRepository<UserEntity, Long> {
     fun findByEmail(email: String): UserEntity?
     fun existsByEmail(email: String): Boolean
+    fun findByNickname(nickname: String): UserEntity?
 }

--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/exception/UserErrorCode.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/exception/UserErrorCode.kt
@@ -10,7 +10,8 @@ enum class UserErrorCode (
 ) : CustomErrorCode {
 
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "NOT_FOUND", "유저를 찾을 수 없습니다."),
-    USER_ALREADY_EXIST(HttpStatus.CONFLICT, "CONFLICT", "유저가(이메일이) 이미 존재합니다."),
+    USER_EMAIL_ALREADY_EXIST(HttpStatus.CONFLICT, "CONFLICT", "유저가(이메일이) 이미 존재합니다."),
+    USER_NICKNAME_ALREADY_EXIST(HttpStatus.CONFLICT, "CONFLICT", "유저가(닉네임이) 이미 존재합니다."),
     USER_NOT_MATCH(HttpStatus.BAD_REQUEST, "BAD_REQUEST", "이메일 또는 비밀번호가 잘못되었습니다.")
 
 }

--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/presentation/UserController.kt
@@ -3,6 +3,7 @@ package com.socksfactory.naeyangkku.domain.user.presentation
 import com.socksfactory.naeyangkku.domain.user.presentation.dto.request.LoginRequest
 import com.socksfactory.naeyangkku.domain.user.presentation.dto.request.RefreshRequest
 import com.socksfactory.naeyangkku.domain.user.presentation.dto.request.RegisterUserRequest
+import com.socksfactory.naeyangkku.domain.user.presentation.dto.request.UserIdReqeust
 import com.socksfactory.naeyangkku.domain.user.service.UserService
 import com.socksfactory.naeyangkku.global.auth.jwt.JwtInfo
 import com.socksfactory.naeyangkku.global.common.BaseResponse
@@ -29,5 +30,10 @@ class UserController(
     @PostMapping("/refresh")
     fun refreshUser(@RequestBody refreshRequest: RefreshRequest): BaseResponse<String> {
         return userService.refreshToken(refreshRequest)
+    }
+
+    @PostMapping("/nickname")
+    fun getNicknameByUserId(@RequestBody userIdRequest: UserIdReqeust): BaseResponse<String> {
+        return userService.getNicknameByUserId(userIdRequest.userId)
     }
 }

--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/presentation/UserController.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/presentation/UserController.kt
@@ -32,8 +32,8 @@ class UserController(
         return userService.refreshToken(refreshRequest)
     }
 
-    @PostMapping("/nickname")
-    fun getNicknameByUserId(@RequestBody userIdRequest: UserIdReqeust): BaseResponse<String> {
-        return userService.getNicknameByUserId(userIdRequest.userId)
+    @PostMapping("/id")
+    fun getNicknameByUserId(@RequestBody userIdRequest: UserIdReqeust): BaseResponse<Long> {
+        return userService.getUserIdByNickname(userIdRequest.nickname)
     }
 }

--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/presentation/dto/request/UserIdReqeust.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/presentation/dto/request/UserIdReqeust.kt
@@ -1,0 +1,5 @@
+package com.socksfactory.naeyangkku.domain.user.presentation.dto.request
+
+data class UserIdReqeust (
+    val userId: Long = 0
+)

--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/presentation/dto/request/UserIdReqeust.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/presentation/dto/request/UserIdReqeust.kt
@@ -1,5 +1,5 @@
 package com.socksfactory.naeyangkku.domain.user.presentation.dto.request
 
 data class UserIdReqeust (
-    val userId: Long = 0
+    val nickname: String = ""
 )

--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/service/UserService.kt
@@ -10,4 +10,5 @@ interface UserService {
     fun registerUser(registerUserRequest: RegisterUserRequest): BaseResponse<Unit>
     fun loginUser(loginRequest: LoginRequest): BaseResponse<JwtInfo>
     fun refreshToken(refreshRequest: RefreshRequest): BaseResponse<String>
+    fun getNicknameByUserId(userId: Long): BaseResponse<String>
 }

--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/service/UserService.kt
@@ -10,5 +10,5 @@ interface UserService {
     fun registerUser(registerUserRequest: RegisterUserRequest): BaseResponse<Unit>
     fun loginUser(loginRequest: LoginRequest): BaseResponse<JwtInfo>
     fun refreshToken(refreshRequest: RefreshRequest): BaseResponse<String>
-    fun getNicknameByUserId(userId: Long): BaseResponse<String>
+    fun getUserIdByNickname(nickname: String): BaseResponse<Long>
 }

--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/service/UserServiceImpl.kt
@@ -27,7 +27,8 @@ class UserServiceImpl(
     @Transactional
     override fun registerUser(registerUserRequest: RegisterUserRequest): BaseResponse<Unit> {
 
-        if(userRepository.existsByEmail(registerUserRequest.email)) throw CustomException(UserErrorCode.USER_ALREADY_EXIST)
+        if(userRepository.existsByEmail(registerUserRequest.email)) throw CustomException(UserErrorCode.USER_EMAIL_ALREADY_EXIST)
+        if(userRepository.existsByNickname(registerUserRequest.nickname)) throw CustomException(UserErrorCode.USER_NICKNAME_ALREADY_EXIST)
 
         userRepository.save(
             userMapper.toEntity(

--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/service/UserServiceImpl.kt
@@ -78,14 +78,13 @@ class UserServiceImpl(
     }
 
     @Transactional(readOnly = true)
-    override fun getNicknameByUserId(userId: Long): BaseResponse<String> {
-        val user = userRepository.findById(userId).orElseThrow {
-            throw CustomException(UserErrorCode.USER_NOT_FOUND)
-        }
+    override fun getUserIdByNickname(nickname: String): BaseResponse<Long> {
+        val user = userRepository.findByNickname(nickname)
+            ?: throw CustomException(UserErrorCode.USER_NOT_FOUND)
 
         return BaseResponse(
-            message = "닉네임 조회 성공",
-            data = user.nickname
+            message = "유저 ID 조회 성공",
+            data = user.id
         )
     }
 

--- a/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/com/socksfactory/naeyangkku/domain/user/service/UserServiceImpl.kt
@@ -76,4 +76,17 @@ class UserServiceImpl(
             )
         )
     }
+
+    @Transactional(readOnly = true)
+    override fun getNicknameByUserId(userId: Long): BaseResponse<String> {
+        val user = userRepository.findById(userId).orElseThrow {
+            throw CustomException(UserErrorCode.USER_NOT_FOUND)
+        }
+
+        return BaseResponse(
+            message = "닉네임 조회 성공",
+            data = user.nickname
+        )
+    }
+
 }


### PR DESCRIPTION
resolved #14 
닉네임을 통해 유저 ID 조회 하는 API 를 추가했습니다.
이로 인한 닉네임 conflict 를 방지하기 위해 회원가입 로직에 닉네임 유효성 검사를 추가했습니다. 
회원가입 시 닉네임 중복 여부를 확인하여, 중복된 닉네임이 존재할 경우 예외를 반환하도록 구현했습니다.